### PR TITLE
SCRUM-87-Implementar-logout-del-usuario-en-el-backend

### DIFF
--- a/SIAT/settings.py
+++ b/SIAT/settings.py
@@ -141,7 +141,7 @@ SIMPLE_JWT = {
     'AUTH_COOKIE_SAMESITE': 'None' if not DEBUG else 'Lax',  # None solo si Secure=True
     'AUTH_COOKIE_PATH': '/',
     'AUTH_COOKIE_DOMAIN': None,
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=2),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=30),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,

--- a/accidente/analiticas.py
+++ b/accidente/analiticas.py
@@ -217,8 +217,7 @@ class AccidentsByUserView(APIView):
 
         try:
             queryset = Accidente.objects.filter(
-                usuario__cedula=cedula,
-                confirmado=True
+                usuario__cedula=cedula
             )
             serializer = AccidenteSerializer(queryset, many=True)
 
@@ -254,17 +253,13 @@ class AccidentByYear(APIView):
             )
         
         # Filtrar por mes y año de la fecha proporcionada
-        accidentes = Accidente.objects.filter(
+        numAccidentes = Accidente.objects.filter(
             confirmado=True,
             FECHA__year=year
-        )
-        
-        serializer = AccidenteSerializer(accidentes, many=True)
-        
-        resultado = serialize_accidentes(serializer.data)     
+        ).count()
+      
 
         return Response({
-            "count": accidentes.count(),
-            "año": year,
-            "resultados": resultado
+            "Total de accidentes": numAccidentes,
+            "año": year
         })

--- a/login/urls.py
+++ b/login/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import registro_api, CustomTokenObtainPairView, CustomTokenRefreshView, PasswordResetRequestView, PasswordResetConfirmView
+from .views import registro_api, CustomTokenObtainPairView, CustomTokenRefreshView, PasswordResetRequestView, PasswordResetConfirmView, LogoutView
 from django.contrib.auth import views as auth_views
 
 urlpatterns = [
@@ -8,4 +8,5 @@ urlpatterns = [
     path('refresh/', CustomTokenRefreshView.as_view(), name='refrescarToken'),
     path('password-reset/request/', PasswordResetRequestView.as_view(), name='password_reset_request'),
     path('password-reset/confirm/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
+    path('logout/', LogoutView.as_view(), name='logout'),
 ]


### PR DESCRIPTION
This pull request introduces several changes across multiple files to update authentication behavior, enhance API endpoints, and improve logout functionality. Key updates include reducing the access token lifetime, modifying query logic in accident analytics, adding a logout endpoint, and implementing a more robust logout process with token blacklisting.

### Authentication Updates:
* [`SIAT/settings.py`](diffhunk://#diff-c33efc295f5b1b5ebaa2e51a6f32386c02c9f24d81e598395df712be16391f5cL144-R144): Reduced `ACCESS_TOKEN_LIFETIME` from 60 minutes to 2 minutes to enhance security by requiring more frequent re-authentication.

### Accident Analytics Enhancements:
* [`accidente/analiticas.py`](diffhunk://#diff-7b515b1376e42bb441c723f8ead0b7a7f0c9dace910464889b8d8ba6b894afa3L220-R220): Removed the `confirmado=True` filter from the first query to include all accidents regardless of confirmation status. Updated the second query to count accidents instead of serializing them, simplifying the response structure. [[1]](diffhunk://#diff-7b515b1376e42bb441c723f8ead0b7a7f0c9dace910464889b8d8ba6b894afa3L220-R220) [[2]](diffhunk://#diff-7b515b1376e42bb441c723f8ead0b7a7f0c9dace910464889b8d8ba6b894afa3L257-R264)

### Logout Functionality:
* [`login/urls.py`](diffhunk://#diff-93df70a77125d74c6158b93c9a4db0d297639ec4086c782177a21a122ee1497eL2-R2): Added a new route for the logout endpoint (`LogoutView`). [[1]](diffhunk://#diff-93df70a77125d74c6158b93c9a4db0d297639ec4086c782177a21a122ee1497eL2-R2) [[2]](diffhunk://#diff-93df70a77125d74c6158b93c9a4db0d297639ec4086c782177a21a122ee1497eR11)
* [`login/views.py`](diffhunk://#diff-fd78965392b495c46db8a2aaf92523923c98d3b3078eb4110ff4bd4b45fb76f0R13-R14): Introduced `LogoutView` with `IsAuthenticated` permission, implemented token blacklisting for secure logout, and added error handling for invalid or expired tokens. [[1]](diffhunk://#diff-fd78965392b495c46db8a2aaf92523923c98d3b3078eb4110ff4bd4b45fb76f0R13-R14) [[2]](diffhunk://#diff-fd78965392b495c46db8a2aaf92523923c98d3b3078eb4110ff4bd4b45fb76f0L132-R160)