### PR TITLE
Se corrigio el manejo del error en el registro de accidentes

### DIFF
--- a/SIAT/utils/custom_exception_handler.py
+++ b/SIAT/utils/custom_exception_handler.py
@@ -15,7 +15,7 @@ def custom_exception_handler(exc, context):
         # También puedes personalizar otros mensajes aquí:
         elif mensaje == "Invalid token.":
             response.data = {"CODE_ERR": "INVALID_TOKEN."}
-            response.status_code = status.HTTP_401_UNAUTHORIZED 
+            response.status_code = status.HTTP_403_FORBIDDEN
 
         elif mensaje == "Given token not valid for any token type":
             response.data = {"CODE_ERR": "INVALID_TOKEN."}
@@ -24,4 +24,8 @@ def custom_exception_handler(exc, context):
         elif mensaje == "Token is blacklisted":
             response.data = {"CODE_ERR": "TOKEN_IS_BLACKLISTED."}
             response.status_code = status.HTTP_401_UNAUTHORIZED
+        # Mensaje cuando no esta autorizado
+        elif mensaje == "Unauthorized":
+            response.data = {"CODE_ERR": "UNAUTHORIZED."}
+            response.status_code = status.HTTP_403_FORBIDDEN
     return response

--- a/accidente/analiticas.py
+++ b/accidente/analiticas.py
@@ -25,7 +25,6 @@ def serialize_accidentes(data):
         serialized.append(item_copy)
     return serialized
 
-
 class FilterAccidentByMonthView(APIView):
     def get(self, request):
         fecha_str = request.GET.get('fecha')  # Obtener la fecha del request
@@ -98,9 +97,7 @@ class RecentlyAccidentView(APIView):
     def get(self, request):
         try:
             # Obtener los últimos 3 accidentes confirmados
-            accidentes = Accidente.objects.filter(
-                confirmado=True
-            ).order_by('-FECHA')[:3]
+            accidentes = Accidente.objects.filter().order_by('-FECHA')[:3]
             
             serializer = AccidenteSerializer(accidentes, many=True)
             


### PR DESCRIPTION
This pull request includes updates to the exception handling logic and optimizations in the accident analytics module. The most important changes involve modifying HTTP status codes for specific error messages, adding a new error case, and simplifying a query for recently confirmed accidents.

### Updates to exception handling:

* [`SIAT/utils/custom_exception_handler.py`](diffhunk://#diff-97614f5b27206e5f1457d1f94f65bd99eeb0986c85e1bda80dc4d844d4c99809L18-R18): Changed the HTTP status code for the "Invalid token." error from `401 Unauthorized` to `403 Forbidden` to better reflect the nature of the error.
* [`SIAT/utils/custom_exception_handler.py`](diffhunk://#diff-97614f5b27206e5f1457d1f94f65bd99eeb0986c85e1bda80dc4d844d4c99809R27-R30): Added a new error case for the "Unauthorized" message, returning a `403 Forbidden` status code and a corresponding error response.

### Accident analytics optimizations:

* [`accidente/analiticas.py`](diffhunk://#diff-7b515b1376e42bb441c723f8ead0b7a7f0c9dace910464889b8d8ba6b894afa3L28): Removed an unnecessary newline in the `serialize_accidentes` function for better code formatting.
* [`accidente/analiticas.py`](diffhunk://#diff-7b515b1376e42bb441c723f8ead0b7a7f0c9dace910464889b8d8ba6b894afa3L101-R100): Simplified the query in the `RecentlyAccidentView` class by removing the filter condition for confirmed accidents. This now retrieves the latest three accidents regardless of their confirmation status.